### PR TITLE
Release 3.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Fork info
+This repo has been forked because we needed to add [this](https://github.com/geosolutions-it/espree/tree/58084900bd57afdcfe0b9dca80ca9a1419c1d693) fix
+We are going to publish the **release** branch on npm GeoSolutions registry
+
+
 # Espree
 
 Espree started out as a fork of [Esprima](http://esprima.org) v1.2.2, the last stable published released of Esprima before work on ECMAScript 6 began. Espree is now built on top of [Acorn](https://github.com/ternjs/acorn), which has a modular architecture that allows extension of core functionality. The goal of Espree is to produce output that is similar to Esprima with a similar API so that it can be used in place of Esprima.

--- a/espree.js
+++ b/espree.js
@@ -61,7 +61,7 @@
 var astNodeTypes = require("./lib/ast-node-types"),
     commentAttachment = require("./lib/comment-attachment"),
     TokenTranslator = require("./lib/token-translator"),
-    acornJSX = require("acorn-jsx/inject"),
+    acornJSX = require("@geosolutions/acorn-jsx/inject"),
     rawAcorn = require("acorn");
 
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "espree",
+  "name": "@geosolutions/espree",
   "description": "An Esprima-compatible JavaScript parser built on Acorn",
   "author": "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
   "homepage": "https://github.com/eslint/espree",
   "main": "espree.js",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "files": [
     "lib",
     "espree.js"
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/eslint/espree.git"
+    "url": "git+https://github.com/geosolutions-it/espree.git"
   },
   "bugs": {
     "url": "http://github.com/eslint/espree.git"
@@ -22,7 +22,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "acorn": "^3.3.0",
-    "acorn-jsx": "https://github.com/geosolutions-it/acorn-jsx/tarball/master"
+    "@geosolutions/acorn-jsx": "4.0.2"
   },
   "devDependencies": {
     "browserify": "^7.0.0",
@@ -58,5 +58,10 @@
     "alpharelease": "eslint-prelease alpha",
     "betarelease": "eslint-prelease beta",
     "browserify": "node Makefile.js browserify"
+  },
+  "directories": {
+    "doc": "docs",
+    "lib": "lib",
+    "test": "tests"
   }
 }


### PR DESCRIPTION
Pushing new package json

before publishing it on npm

this lib is used in jsdoc that is used in mapstore2